### PR TITLE
Make sure django is 1.8 or higher

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
 
     install_requires=[
         'wagtail>=1.4',
+        'Django>=1.8',
         'django-enumchoicefield==0.6.0',
     ],
     extras_require={


### PR DESCRIPTION
When trying to migrate wagtailvideos when using a django version lower than 1.9, an error such as the below will be raised:
```
psycopg2.ProgrammingError: column "duration" cannot be cast automatically to type interval
HINT:  You might need to specify "USING duration::interval".
```
This is because the `DurationField` is new in Django 1.8. 

Ensuring the user has Django 1.8 or higher installed will fix this issue.