### PR TITLE
Add Wagtail 1.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,45 +8,23 @@ env:
   matrix:
     - TOX_ENV=flake8,isort
 
+
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+
+env:
+  - DJANGO='19' WAGTAIL='17'
+  - DJANGO='110' WAGTAIL='17'
+  - DJANGO='19' WAGTAIL='18'
+  - DJANGO='110' WAGTAIL='18'
+
+
 matrix:
-  - env: DJANGO='18' WAGTAIL='14'
-    python: 2.7
-  - env: DJANGO='18' WAGTAIL='14'
-    python: 3.4
-  - env: DJANGO='18' WAGTAIL='14'
-    python: 3.5
-  - env: DJANGO='19' WAGTAIL='14'
-    python: 2.7
-  - env: DJANGO='19' WAGTAIL='14'
-    python: 3.4
-  - env: DJANGO='19' WAGTAIL='14'
-    python: 3.5
-  - env: DJANGO='18' WAGTAIL='15'
-    python: 2.7
-  - env: DJANGO='18' WAGTAIL='15'
-    python: 3.4
-  - env: DJANGO='18' WAGTAIL='15'
-    python: 3.5
-  - env: DJANGO='19' WAGTAIL='15'
-    python: 2.7
-  - env: DJANGO='19' WAGTAIL='15'
-    python: 3.4
-  - env: DJANGO='19' WAGTAIL='15'
-    python: 3.5
-  - env: DJANGO='19' WAGTAIL='16'
-    python: 2.7
-  - env: DJANGO='19' WAGTAIL='16'
-    python: 3.4
-  - env: DJANGO='19' WAGTAIL='16'
-    python: 3.5
-  - env: DJANGO='110' WAGTAIL='16'
-    python: 2.7
-  - env: DJANGO='110' WAGTAIL='16'
-    python: 3.4
-  - env: DJANGO='110' WAGTAIL='16'
-    python: 3.5
-  - env: TOX_ENV='flake8,isort'
-    python: 3.5
+  include:
+    - env: TOX_ENV='flake8,isort'
+      python: 3.5
 
 before_install:
     # - sudo add-apt-repository ppa:mc3man/trusty-media -y // Inlcudes all multimedia options but 404s currently :(

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ html5 compliant codec using ffmpeg.
 Requirements
 ------------
 
--  Wagtail > 1.4
+-  Wagtail > 1.7
 -  `ffmpeg <https://ffmpeg.org/>`__
 
 Installing

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ setup(
     url='https://github.com/takeflight/wagtailvideos',
 
     install_requires=[
-        'wagtail>=1.4',
-        'Django>=1.8',
+        'wagtail>=1.7',
+        'Django>=1.9',
         'django-enumchoicefield==0.6.0',
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,7 @@
 skip_missing_interpreters = True
 
 envlist =
-	# Wagtail LTS
-	py{27,34,35}-dj{18,19}-wt14
-	# Last version
-	py{27,34,35}-dj{18,19}-wt15
-	# Current version
-	py{27,34,35}-dj{19,110}-wt16
+	py{27,34,35}-dj{19,110}-wt{17,18}
 	# Enforce good style
 	flake8,isort
 
@@ -23,10 +18,8 @@ deps =
 	dj18: Django~=1.8.0
 	dj19: Django~=1.9.0
 	dj110: Django~=1.10.0
-	wt13: wagtail~=1.3.0
-	wt14: wagtail~=1.4.0
-	wt15: wagtail~=1.5.0
-	wt16: wagtail~=1.6.0
+	wt17: wagtail~=1.7.0
+	wt18: wagtail~=1.8rc1
 
 [testenv:flake8]
 deps = flake8

--- a/wagtailvideos/jinja2tags.py
+++ b/wagtailvideos/jinja2tags.py
@@ -23,4 +23,5 @@ class WagtailVideosExtension(Extension):
             'video': video,
         })
 
+
 videos = WagtailVideosExtension

--- a/wagtailvideos/migrations/0001_initial.py
+++ b/wagtailvideos/migrations/0001_initial.py
@@ -4,8 +4,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import django.db.models.deletion
 import taggit.managers
-import wagtail.wagtailadmin.taggable
 import wagtail.wagtailcore.models
+import wagtail.wagtailsearch.index
 from django.conf import settings
 from django.db import migrations, models
 
@@ -38,6 +38,6 @@ class Migration(migrations.Migration):
             options={
                 'abstract': False,
             },
-            bases=(models.Model, wagtail.wagtailadmin.taggable.TagSearchable),
+            bases=(models.Model,),
         ),
     ]

--- a/wagtailvideos/views/chooser.py
+++ b/wagtailvideos/views/chooser.py
@@ -7,7 +7,8 @@ from django.shortcuts import get_object_or_404, render
 from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
-from wagtail.wagtailadmin.utils import PermissionPolicyChecker
+from wagtail.wagtailadmin.utils import (
+    PermissionPolicyChecker, popular_tags_for_model)
 from wagtail.wagtailcore.models import Collection
 from wagtail.wagtailsearch import index as search_index
 from wagtail.wagtailsearch.backends import get_search_backends
@@ -88,7 +89,7 @@ def chooser(request):
         'searchform': searchform,
         'is_searching': False,
         'query_string': q,
-        'popular_tags': Video.popular_tags(),
+        'popular_tags': popular_tags_for_model(Video),
         'collections': collections,
     })
 

--- a/wagtailvideos/views/videos.py
+++ b/wagtailvideos/views/videos.py
@@ -10,7 +10,8 @@ from django.views.decorators.vary import vary_on_headers
 from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin import messages
 from wagtail.wagtailadmin.forms import SearchForm
-from wagtail.wagtailadmin.utils import PermissionPolicyChecker
+from wagtail.wagtailadmin.utils import (
+    PermissionPolicyChecker, popular_tags_for_model)
 from wagtail.wagtailcore.models import Collection
 from wagtail.wagtailsearch.backends import get_search_backends
 
@@ -66,7 +67,7 @@ def index(request):
             'is_searching': bool(query_string),
 
             'search_form': form,
-            'popular_tags': Video.popular_tags(),
+            'popular_tags': popular_tags_for_model(Video),
             'current_collection': current_collection,
         })
         return response


### PR DESCRIPTION
Mostly involved removing references to TagSearchable, a class which has been removed.

Wagtailvideo claimed support back to 1.4, which was lies. I've changed the supported versions to be Wagtail 1.7 and 1.8, Django 1.9 and 1.10. It might work on older versions, but this support is not guaranteed.

Fixes #13 