### PR TITLE
Make file input field not required when editing

### DIFF
--- a/tests/test_admin_views.py
+++ b/tests/test_admin_views.py
@@ -9,10 +9,9 @@ from django.core.urlresolvers import reverse
 from django.template.defaultfilters import filesizeformat
 from django.test import TestCase, override_settings
 from mock import patch
+from tests.utils import create_test_video_file
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailcore.models import Collection, GroupCollectionPermission
-
-from tests.utils import create_test_video_file
 from wagtailvideos.models import Video
 
 
@@ -228,6 +227,7 @@ class TestVideoEditView(TestCase, WagtailTestUtils):
         # Check that the video was edited
         video = Video.objects.get(id=self.video.id)
         self.assertEqual(video.title, "Edited")
+        self.assertEqual(self.video.file, video.file)
 
     def test_edit_with_new_video_file(self):
         # Change the file size of the video

--- a/tests/test_admin_views.py
+++ b/tests/test_admin_views.py
@@ -9,9 +9,10 @@ from django.core.urlresolvers import reverse
 from django.template.defaultfilters import filesizeformat
 from django.test import TestCase, override_settings
 from mock import patch
-from tests.utils import create_test_video_file
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailcore.models import Collection, GroupCollectionPermission
+
+from tests.utils import create_test_video_file
 from wagtailvideos.models import Video
 
 

--- a/wagtailvideos/forms.py
+++ b/wagtailvideos/forms.py
@@ -7,6 +7,7 @@ from enumchoicefield.forms import EnumField
 from wagtail.wagtailadmin import widgets
 from wagtail.wagtailadmin.forms import (
     BaseCollectionMemberForm, collection_member_permission_formset_factory)
+
 from wagtailvideos.fields import WagtailVideoField
 from wagtailvideos.models import MediaFormats, Video, VideoQuality
 from wagtailvideos.permissions import \

--- a/wagtailvideos/forms.py
+++ b/wagtailvideos/forms.py
@@ -7,7 +7,6 @@ from enumchoicefield.forms import EnumField
 from wagtail.wagtailadmin import widgets
 from wagtail.wagtailadmin.forms import (
     BaseCollectionMemberForm, collection_member_permission_formset_factory)
-
 from wagtailvideos.fields import WagtailVideoField
 from wagtailvideos.models import MediaFormats, Video, VideoQuality
 from wagtailvideos.permissions import \
@@ -16,6 +15,14 @@ from wagtailvideos.permissions import \
 
 class BaseVideoForm(BaseCollectionMemberForm):
     permission_policy = video_permission_policy
+
+    def __init__(self, *args, **kwargs):
+        super(BaseVideoForm, self).__init__(*args, **kwargs)
+        # A file is only required if there is not already a file, such as when
+        # editing an existing video.  The file field is not used on the
+        # multiple-upload forms, so may not be present
+        if 'file' in self.fields:
+            self.fields['file'].required = 'file' not in self.initial or not self.initial['file']
 
 
 # Callback to allow us to override the default form field for the image file field

--- a/wagtailvideos/models.py
+++ b/wagtailvideos/models.py
@@ -27,6 +27,7 @@ from wagtail.wagtailadmin.utils import get_object_usage
 from wagtail.wagtailcore.models import CollectionMember
 from wagtail.wagtailsearch import index
 from wagtail.wagtailsearch.queryset import SearchableQuerySetMixin
+
 from wagtailvideos.utils import ffmpeg_installed
 
 logger = logging.getLogger(__name__)

--- a/wagtailvideos/models.py
+++ b/wagtailvideos/models.py
@@ -11,7 +11,6 @@ import subprocess
 import tempfile
 import threading
 
-import django
 from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.urlresolvers import reverse
@@ -28,7 +27,6 @@ from wagtail.wagtailadmin.utils import get_object_usage
 from wagtail.wagtailcore.models import CollectionMember
 from wagtail.wagtailsearch import index
 from wagtail.wagtailsearch.queryset import SearchableQuerySetMixin
-
 from wagtailvideos.utils import ffmpeg_installed
 
 logger = logging.getLogger(__name__)

--- a/wagtailvideos/views/chooser.py
+++ b/wagtailvideos/views/chooser.py
@@ -11,6 +11,7 @@ from wagtail.wagtailadmin.utils import (
     PermissionPolicyChecker, popular_tags_for_model)
 from wagtail.wagtailcore.models import Collection
 from wagtail.wagtailsearch import index as search_index
+
 from wagtailvideos.forms import get_video_form
 from wagtailvideos.models import Video
 from wagtailvideos.permissions import permission_policy

--- a/wagtailvideos/views/chooser.py
+++ b/wagtailvideos/views/chooser.py
@@ -11,8 +11,6 @@ from wagtail.wagtailadmin.utils import (
     PermissionPolicyChecker, popular_tags_for_model)
 from wagtail.wagtailcore.models import Collection
 from wagtail.wagtailsearch import index as search_index
-from wagtail.wagtailsearch.backends import get_search_backends
-
 from wagtailvideos.forms import get_video_form
 from wagtailvideos.models import Video
 from wagtailvideos.permissions import permission_policy

--- a/wagtailvideos/views/videos.py
+++ b/wagtailvideos/views/videos.py
@@ -14,7 +14,6 @@ from wagtail.wagtailadmin.utils import (
     PermissionPolicyChecker, popular_tags_for_model)
 from wagtail.wagtailcore.models import Collection
 from wagtail.wagtailsearch.backends import get_search_backends
-
 from wagtailvideos.forms import VideoTranscodeAdminForm, get_video_form
 from wagtailvideos.models import Video
 from wagtailvideos.permissions import permission_policy
@@ -76,7 +75,6 @@ def index(request):
 @permission_checker.require('change')
 def edit(request, video_id):
     VideoForm = get_video_form(Video)
-
     video = get_object_or_404(Video, id=video_id)
 
     if request.POST:

--- a/wagtailvideos/views/videos.py
+++ b/wagtailvideos/views/videos.py
@@ -14,6 +14,7 @@ from wagtail.wagtailadmin.utils import (
     PermissionPolicyChecker, popular_tags_for_model)
 from wagtail.wagtailcore.models import Collection
 from wagtail.wagtailsearch.backends import get_search_backends
+
 from wagtailvideos.forms import VideoTranscodeAdminForm, get_video_form
 from wagtailvideos.models import Video
 from wagtailvideos.permissions import permission_policy

--- a/wagtailvideos/wagtail_hooks.py
+++ b/wagtailvideos/wagtail_hooks.py
@@ -8,9 +8,8 @@ from django.utils.translation import ugettext_lazy as _
 from wagtail.wagtailadmin.menu import MenuItem
 from wagtail.wagtailcore import hooks
 
+from wagtailvideos import urls
 from wagtailvideos.forms import GroupVideoPermissionFormSet
-
-from . import urls
 
 
 @hooks.register('register_admin_urls')


### PR DESCRIPTION
Change input template for file input to ensure the required attribute is not present.

Fix for #17.